### PR TITLE
Add multi-colored graphing

### DIFF
--- a/app/functions.js
+++ b/app/functions.js
@@ -8,44 +8,48 @@ export function coloralloc(sgv, lowthres, hithresh, multicolbool){
     }
     return clr;
   }
-  if (sgv >= hithresh*2.6){
-    clr= '#e3b4f3';
-  } else if (sgv > hithresh*2.4) {
-    clr= '#D6A7E6';
-  } else if (sgv > hithresh*2.2) {
-    clr= '#b800f5';
-  } else if (sgv > hithresh*2.00) {
-    clr= '#d452ff';
-  } else if (sgv > hithresh*1.80) {
-    clr= '#fd20d7';
-  } else if (sgv > hithresh*1.70) {
-    clr= '#ee59d5';
-  } else if (sgv > hithresh*1.60) {
-    clr= '#f38ee2';
-  } else if (sgv > hithresh*1.50) {
-    clr= '#f44496';
-  } else if (sgv > hithresh*1.40) {
-    clr= '#f76767';
-  } else if (sgv > hithresh*1.30) {
-    clr= '#f93434';
-  } else if (sgv > hithresh*1.20) {
-    clr= '#FF5722';
-  } else if (sgv > hithresh*1.15) {
-    clr= '#ffa500';
-  } else if (sgv > hithresh*1.10) {
-    clr= '#ffbf00';
-  } else if (sgv > hithresh) {
-    clr= '#ffff00';
-  } else if (sgv > hithresh*0.80) {
-    clr= '#aaee02';
-  } else if (sgv > hithresh*0.65) {
-    clr= '#3fce02';
-  } else if (sgv > lowthres*1.20) {
-    clr= '#02ad27';
-  } else if (sgv > lowthres) {
-    clr= '#06bbbb';
-  }else{
-    clr= '#2196f3';
+  //check if the hi threshold is 1.2 times the low threshold.
+  if (hithresh > (lowthres*1.20)) {
+    //start allocating color based on the thresholds
+    if (sgv >= hithresh*2.6){
+      clr= '#e3b4f3';
+    } else if (sgv > hithresh*2.4) {
+      clr= '#D6A7E6';
+    } else if (sgv > hithresh*2.2) {
+      clr= '#b800f5';
+    } else if (sgv > hithresh*2.00) {
+      clr= '#d452ff';
+    } else if (sgv > hithresh*1.80) {
+      clr= '#fd20d7';
+    } else if (sgv > hithresh*1.70) {
+      clr= '#ee59d5';
+    } else if (sgv > hithresh*1.60) {
+      clr= '#f38ee2';
+    } else if (sgv > hithresh*1.50) {
+      clr= '#f44496';
+    } else if (sgv > hithresh*1.40) {
+      clr= '#f76767';
+    } else if (sgv > hithresh*1.30) {
+      clr= '#f93434';
+    } else if (sgv > hithresh*1.20) {
+      clr= '#FF5722';
+    } else if (sgv > hithresh*1.15) {
+      clr= '#ffa500';
+    } else if (sgv > hithresh*1.10) {
+      clr= '#ffbf00';
+    } else if (sgv > hithresh) {
+      clr= '#ffff00';
+    } else if (sgv > hithresh*0.80) {
+      clr= '#aaee02';
+    } else if (sgv > hithresh*0.65) {
+      clr= '#3fce02';
+    } else if (sgv > lowthres*1.20) {
+      clr= '#02ad27';
+    } else if (sgv > lowthres) {
+      clr= '#06bbbb';
+    }else{
+      clr= '#2196f3';
+    }
   }
   return clr;
 }

--- a/app/functions.js
+++ b/app/functions.js
@@ -1,0 +1,51 @@
+export function coloralloc(sgv, lowthres, hithresh, multicolbool){
+  let clr = "green";
+  if(!multicolbool){
+    if (sgv >= hithresh) {
+      clr= "red";
+    } else if (sgv <= lowthres) {
+      clr = "red";
+    }
+    return clr;
+  }
+  if (sgv >= hithresh*2.6){
+    clr= '#e3b4f3';
+  } else if (sgv > hithresh*2.4) {
+    clr= '#D6A7E6';
+  } else if (sgv > hithresh*2.2) {
+    clr= '#b800f5';
+  } else if (sgv > hithresh*2.00) {
+    clr= '#d452ff';
+  } else if (sgv > hithresh*1.80) {
+    clr= '#fd20d7';
+  } else if (sgv > hithresh*1.70) {
+    clr= '#ee59d5';
+  } else if (sgv > hithresh*1.60) {
+    clr= '#f38ee2';
+  } else if (sgv > hithresh*1.50) {
+    clr= '#f44496';
+  } else if (sgv > hithresh*1.40) {
+    clr= '#f76767';
+  } else if (sgv > hithresh*1.30) {
+    clr= '#f93434';
+  } else if (sgv > hithresh*1.20) {
+    clr= '#FF5722';
+  } else if (sgv > hithresh*1.15) {
+    clr= '#ffa500';
+  } else if (sgv > hithresh*1.10) {
+    clr= '#ffbf00';
+  } else if (sgv > hithresh) {
+    clr= '#ffff00';
+  } else if (sgv > hithresh*0.80) {
+    clr= '#aaee02';
+  } else if (sgv > hithresh*0.65) {
+    clr= '#3fce02';
+  } else if (sgv > lowthres*1.20) {
+    clr= '#02ad27';
+  } else if (sgv > lowthres) {
+    clr= '#06bbbb';
+  }else{
+    clr= '#2196f3';
+  }
+  return clr;
+}

--- a/app/graph.js
+++ b/app/graph.js
@@ -171,7 +171,7 @@ export default class Graph {
       }
       sgvHigh = Math.floor(sgvHigh*1.1); // Give some space for the highest dots
     }
-    
+
     const range = sgvHigh - sgvLow;
 
     function getYFromSgv (sgv) {
@@ -197,6 +197,47 @@ export default class Graph {
       dot.style.fill = 'green';
       if (sgv.sgv >= settings.highThreshold || sgv.sgv <= settings.lowThreshold) {
         dot.style.fill = 'red';
+      }
+      if (settings.multicolor){
+        if (sgv.sgv >= 360){
+          dot.style.fill = '#e3b4f3';
+        } else if (sgv.sgv > 340) {
+          dot.style.fill = '#D6A7E6';
+        } else if (sgv.sgv > 300) {
+          dot.style.fill = '#b800f5';
+        } else if (sgv.sgv > 280) {
+          dot.style.fill = '#d452ff';
+        } else if (sgv.sgv > 260) {
+          dot.style.fill = '#fd20d7';
+        } else if (sgv.sgv > 240) {
+          dot.style.fill = '#ee59d5';
+        } else if (sgv.sgv > 200) {
+          dot.style.fill = '#f38ee2';
+        } else if (sgv.sgv > 190) {
+          dot.style.fill = '#f44496';
+        } else if (sgv.sgv > 180) {
+          dot.style.fill = '#f76767';
+        } else if (sgv.sgv > 170) {
+          dot.style.fill = '#f93434';
+        } else if (sgv.sgv > 160) {
+          dot.style.fill = '#FF5722';
+        } else if (sgv.sgv > 150) {
+          dot.style.fill = '#ffa500';
+        } else if (sgv.sgv > 140) {
+          dot.style.fill = '#ffbf00';
+        } else if (sgv.sgv > 135) {
+          dot.style.fill = '#ffff00';
+        } else if (sgv.sgv > 125) {
+          dot.style.fill = '#dbef02';
+        } else if (sgv.sgv > 100) {
+          dot.style.fill = '#3fce02';
+        } else if (sgv.sgv > 70) {
+          dot.style.fill = '#02ad27';
+        } else if (sgv.sgv > 66) {
+          dot.style.fill = '#06bbbb';
+        }else{
+          dot.style.fill = '#2196f3';
+        }
       }
       dot.style.visibility = 'visible';
     }

--- a/app/graph.js
+++ b/app/graph.js
@@ -1,6 +1,6 @@
 import { me as device } from "device";
 import dataProcessor from '../companion/dataprocessing';
-
+import {coloralloc} from "./functions.js";
 // Screen dimension fallback for older firmware
 if (!device.screen) device.screen = {
   width: 348
@@ -199,46 +199,9 @@ export default class Graph {
         dot.style.fill = 'red';
       }
       if (settings.multicolor){
-        if (sgv.sgv >= 360){
-          dot.style.fill = '#e3b4f3';
-        } else if (sgv.sgv > 340) {
-          dot.style.fill = '#D6A7E6';
-        } else if (sgv.sgv > 300) {
-          dot.style.fill = '#b800f5';
-        } else if (sgv.sgv > 280) {
-          dot.style.fill = '#d452ff';
-        } else if (sgv.sgv > 260) {
-          dot.style.fill = '#fd20d7';
-        } else if (sgv.sgv > 240) {
-          dot.style.fill = '#ee59d5';
-        } else if (sgv.sgv > 200) {
-          dot.style.fill = '#f38ee2';
-        } else if (sgv.sgv > 190) {
-          dot.style.fill = '#f44496';
-        } else if (sgv.sgv > 180) {
-          dot.style.fill = '#f76767';
-        } else if (sgv.sgv > 170) {
-          dot.style.fill = '#f93434';
-        } else if (sgv.sgv > 160) {
-          dot.style.fill = '#FF5722';
-        } else if (sgv.sgv > 150) {
-          dot.style.fill = '#ffa500';
-        } else if (sgv.sgv > 140) {
-          dot.style.fill = '#ffbf00';
-        } else if (sgv.sgv > 135) {
-          dot.style.fill = '#ffff00';
-        } else if (sgv.sgv > 125) {
-          dot.style.fill = '#aaee02';
-        } else if (sgv.sgv > 100) {
-          dot.style.fill = '#3fce02';
-        } else if (sgv.sgv > 70) {
-          dot.style.fill = '#02ad27';
-        } else if (sgv.sgv > 66) {
-          dot.style.fill = '#06bbbb';
-        }else{
-          dot.style.fill = '#2196f3';
+        //set color based on thresholds
+        dot.style.fill = coloralloc(sgv.sgv, settings.lowThreshold, settings.highThreshold, settings.multicolor);
         }
-      }
       dot.style.visibility = 'visible';
     }
 

--- a/app/graph.js
+++ b/app/graph.js
@@ -228,7 +228,7 @@ export default class Graph {
         } else if (sgv.sgv > 135) {
           dot.style.fill = '#ffff00';
         } else if (sgv.sgv > 125) {
-          dot.style.fill = '#dbef02';
+          dot.style.fill = '#aaee02';
         } else if (sgv.sgv > 100) {
           dot.style.fill = '#3fce02';
         } else if (sgv.sgv > 70) {

--- a/app/index.js
+++ b/app/index.js
@@ -72,7 +72,7 @@ function mmol (bg) {
   return mmolBG.toFixed(1);
 }
 
-// converts mmoL to  mg/dL 
+// converts mmoL to  mg/dL
 function mgdl (bg) {
   let mgdlBG = Math.round((bg * 18) / 10) * 10;
   return mgdlBG;
@@ -106,7 +106,7 @@ hrm.start();
 
 //----------------------------------------------------------
 //
-// This section deals with getting data from the companion app 
+// This section deals with getting data from the companion app
 //
 //----------------------------------------------------------
 // Request data from the companion
@@ -138,6 +138,47 @@ function updateScreenWithLatestGlucose (data, prevEntry) {
     } else {
       tcolor = "green";
     }
+    if (settings.multicolor){
+      if (data.sgv >= 360){
+        tcolor = '#e3b4f3';
+      } else if (data.sgv > 340) {
+        tcolor = '#D6A7E6';
+      } else if (data.sgv > 300) {
+        tcolor = '#b800f5';
+      } else if (data.sgv > 280) {
+        tcolor = '#d452ff';
+      } else if (data.sgv > 260) {
+        tcolor = '#fd20d7';
+      } else if (data.sgv > 240) {
+        tcolor = '#ee59d5';
+      } else if (data.sgv > 200) {
+        tcolor = '#f38ee2';
+      } else if (data.sgv > 190) {
+        tcolor = '#f44496';
+      } else if (data.sgv > 180) {
+        tcolor = '#f76767';
+      } else if (data.sgv > 170) {
+        tcolor = '#f93434';
+      } else if (data.sgv > 160) {
+        tcolor = '#FF5722';
+      } else if (data.sgv > 150) {
+        tcolor = '#ffa500';
+      } else if (data.sgv > 140) {
+        tcolor = '#ffbf00';
+      } else if (data.sgv > 135) {
+        tcolor = '#ffff00';
+      } else if (data.sgv > 125) {
+        tcolor = '#dbef02';
+      } else if (data.sgv > 100) {
+        tcolor = '#3fce02';
+      } else if (data.sgv > 70) {
+        tcolor = '#02ad27';
+      } else if (data.sgv > 66) {
+        tcolor = '#06bbbb';
+      }else{
+        tcolor = '#2196f3';
+      }
+    }
 
     sgv.text = settings.units == 'mgdl' ? data.sgv : mmol(data.sgv) + "" + arrowIcon[data.direction];
     sgv.style.fill = tcolor;
@@ -167,8 +208,8 @@ function updateScreenWithLatestGlucose (data, prevEntry) {
 
     if (deltaValue > 0) {
       deltaString = '+' + deltaString;
-    } 
-    
+    }
+
     delta.text = deltaString;
 
   } else {
@@ -234,7 +275,7 @@ function readSGVFile (filename) {
   statusStrings["IOB"] = state.iob ? "IOB " + state.iob : "IOB ???";
   statusStrings["COB"] = state.iob ? "COB " + state.cob : "COB ???";
   statusStrings["BWP"] = state.iob ? "BWP " + state.bwp : "BWP ???";
-  
+
   const s1 = settings.statusLine1 || "IOB";
   const s2 = settings.statusLine2 || "COB";
 
@@ -382,7 +423,7 @@ btnRight.onclick = function(evt) {
 
 const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-// The updater is used to update the screen every 1 SECONDS 
+// The updater is used to update the screen every 1 SECONDS
 function updateClock () {
 
   const nowDate = new Date();
@@ -390,7 +431,7 @@ function updateClock () {
   const mins = nowDate.getMinutes();
   const month = monthNames[nowDate.getMonth()];
   const day = nowDate.getDate();
-  
+
   if (mins < 10) { mins = `0${mins}`; }
 
   const dateText = `${month} ${day} `;

--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,7 @@ import { preferences } from "user-settings";
 import { today } from "user-activity";
 import { HeartRateSensor } from "heart-rate";
 import { battery } from "power";
-
+import {coloralloc} from "./functions.js";
 import Graph from "./graph.js";
 
 // Update the clock every minute
@@ -149,61 +149,9 @@ function updateScreenWithLatestGlucose (data, prevEntry) {
 
   if (data) {
 
-    let tcolor = "white";
-
-    // sgv is always mgdl, but thresholds are unit-specific
-
-    if (data.sgv >= settings.highThreshold) {
-      tcolor = "red";
-    } else if (data.sgv <= settings.lowThreshold) {
-      tcolor = "red";
-    } else {
-      tcolor = "green";
-    }
-    if (settings.multicolor){
-      if (data.sgv >= 360){
-        tcolor = '#e3b4f3';
-      } else if (data.sgv > 340) {
-        tcolor = '#D6A7E6';
-      } else if (data.sgv > 300) {
-        tcolor = '#b800f5';
-      } else if (data.sgv > 280) {
-        tcolor = '#d452ff';
-      } else if (data.sgv > 260) {
-        tcolor = '#fd20d7';
-      } else if (data.sgv > 240) {
-        tcolor = '#ee59d5';
-      } else if (data.sgv > 200) {
-        tcolor = '#f38ee2';
-      } else if (data.sgv > 190) {
-        tcolor = '#f44496';
-      } else if (data.sgv > 180) {
-        tcolor = '#f76767';
-      } else if (data.sgv > 170) {
-        tcolor = '#f93434';
-      } else if (data.sgv > 160) {
-        tcolor = '#FF5722';
-      } else if (data.sgv > 150) {
-        tcolor = '#ffa500';
-      } else if (data.sgv > 140) {
-        tcolor = '#ffbf00';
-      } else if (data.sgv > 135) {
-        tcolor = '#ffff00';
-      } else if (data.sgv > 125) {
-        tcolor = '#aaee02';
-      } else if (data.sgv > 100) {
-        tcolor = '#3fce02';
-      } else if (data.sgv > 70) {
-        tcolor = '#02ad27';
-      } else if (data.sgv > 66) {
-        tcolor = '#06bbbb';
-      }else{
-        tcolor = '#2196f3';
-      }
-    }
-
-    sgv.text = settings.units == 'mgdl' ? data.sgv + "" + arrowIcon[data.direction] : mmol(data.sgv) + "" + arrowIcon[data.direction];
-    sgv.style.fill = tcolor;
+    //hand off to colour threshold function to allocate the color
+    sgv.text = settings.units == 'mgdl' ? data.sgv : mmol(data.sgv) + "" + arrowIcon[data.direction];
+    sgv.style.fill = coloralloc(data.sgv, settings.lowThreshold, settings.highThreshold, settings.multicolor);
 
     //dirArrow.text = arrowIcon[data.direction];
     //dirArrow.style.fill = tcolor;

--- a/app/index.js
+++ b/app/index.js
@@ -168,7 +168,7 @@ function updateScreenWithLatestGlucose (data, prevEntry) {
       } else if (data.sgv > 135) {
         tcolor = '#ffff00';
       } else if (data.sgv > 125) {
-        tcolor = '#dbef02';
+        tcolor = '#aaee02';
       } else if (data.sgv > 100) {
         tcolor = '#3fce02';
       } else if (data.sgv > 70) {

--- a/app/index.js
+++ b/app/index.js
@@ -150,7 +150,7 @@ function updateScreenWithLatestGlucose (data, prevEntry) {
   if (data) {
 
     //hand off to colour threshold function to allocate the color
-    sgv.text = settings.units == 'mgdl' ? data.sgv : mmol(data.sgv) + "" + arrowIcon[data.direction];
+    sgv.text = settings.units == 'mgdl' ? data.sgv + "" + arrowIcon[data.direction] : mmol(data.sgv) + "" + arrowIcon[data.direction];
     sgv.style.fill = coloralloc(data.sgv, settings.lowThreshold, settings.highThreshold, settings.multicolor);
 
     //dirArrow.text = arrowIcon[data.direction];

--- a/companion/settings.js
+++ b/companion/settings.js
@@ -7,7 +7,7 @@ function mmol(bg) {
   return mmolBG;
 }
 
-// converts mmoL to  mg/dL 
+// converts mmoL to  mg/dL
 function mgdl(bg) {
   let mgdlBG = Math.round((bg * 18) / 10) * 10;
   return mgdlBG;
@@ -61,6 +61,8 @@ _settings.parseSettings = function parseSettings() {
 
   settings.units = settingsStorage.getItem('usemgdl') === 'true' ? 'mgdl' : 'mmol';
 
+  settings.multicolor = _settings.getSettings('multicolor', false);
+
   // thresholds are always mgdl
   settings.highThreshold = Number(_settings.getSettings('highThreshold', 200));
   settings.lowThreshold = Number(_settings.getSettings('lowThreshold', 70));
@@ -88,7 +90,7 @@ _settings.parseSettings = function parseSettings() {
 
   settings.cgmHours = Number(_settings.getSettings('cgmHours', 3));
   settings.predictionHours =  Number(_settings.getSettings('predictionHours', 0));
-  
+
   settings.enableAlarms = _settings.getSettings('enableAlarms', false);
 
   let predSteps = _settings.getSettingIndex('alarmPredictions', 0);
@@ -126,7 +128,7 @@ _settings.getURLS = function getURLS() {
 
     return {sgvURL, treatmentURL, pebbleURL, profileURL, v2APIURL};
   } else {
-    // Default xDrip web service 
+    // Default xDrip web service
     return "http://127.0.0.1:17580/sgv.json";
   }
 }
@@ -138,4 +140,3 @@ _settings.setCallback = function(cb) {
 }
 
 export default _settings;
-

--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -19,6 +19,12 @@ function mySettings(props) {
           settingsKey="highThreshold"
         />
 
+        <Toggle
+        settingsKey="multicolor"
+        label={`Multi color BG graph: ${props.settingsStorage.getItem('multicolor') === 'true' ? 'yes' : 'no'}`}
+        onChange={value => props.settingsStorage.getItem('multicolor', value ? 'yes' : 'no')}
+        />
+
         <TextInput
         label="Low BG threshold"
         settingsKey="lowThreshold"


### PR DESCRIPTION
Adds the option to color up the display a bit more, by switching out the standard threshold graphing colors to multi-colored rainbow styled ones.

Tested on Versa-Lite, Versa via Simulator, Versa 2 in person.
Looks like below:
![multi-color](https://user-images.githubusercontent.com/2896311/67610015-72b02600-f7ec-11e9-8383-0ab63dbd5a2d.png)
